### PR TITLE
マイページから`/mypage/edit/{id}`にアクセスできるように修正

### DIFF
--- a/src/app/Http/Controllers/PortfolioController.php
+++ b/src/app/Http/Controllers/PortfolioController.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Product;
 use App\Models\Product_image;
+use App\Models\User;
+
 class PortfolioController extends Controller
 {
     public function index()
@@ -64,8 +66,8 @@ class PortfolioController extends Controller
     
     public function edit($id)
     {
-        $mypage = User::findOrFail($id)->enginner;
-        dd($mypage);
+        $mypage = User::findOrFail($id)->engineer;
+        // dd($mypage);
         return view('mypage.edit', compact('mypage'));
     }
 

--- a/src/app/Http/Controllers/UserpageController.php
+++ b/src/app/Http/Controllers/UserpageController.php
@@ -5,7 +5,8 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\User;
 
-
+// デバッグ用
+use Illuminate\Support\Facades\Log;
 
 class UserpageController extends Controller
 {
@@ -24,10 +25,7 @@ class UserpageController extends Controller
          foreach($products as $product)
          {
              $image = $product->product_images()->first();
-             
              $products_image = array_merge($products_image, array($product->title => $image->image_path));
-             
-            
          }
 
          return view('userpage', [
@@ -37,7 +35,6 @@ class UserpageController extends Controller
              'tags' => $tags,
              'jobs' => $jobs,
              'products_image' => $products_image,
-
          ]);
     }
 }

--- a/src/resources/views/userpage.blade.php
+++ b/src/resources/views/userpage.blade.php
@@ -44,7 +44,7 @@
                         <span class="beforeballoon-left">
                             マイページを編集
                             <div class="balloon-left">
-                                <a href="/mypage/edit">基本情報を編集</a>
+                                <a href="/mypage/edit/{{ $user->id }}">基本情報を編集</a>
                                 <a href="portfolio/edit">製作物を編集</a>
                             </div>
                         </span>


### PR DESCRIPTION
マイページ(`/mypage` or `/{}/view`)から基本情報編集画面(`/mypage/edit/{id}`)への遷移ができていなかったので遷移できるように修正